### PR TITLE
Hotfix for incompatible 2.4.0 version in Alpine

### DIFF
--- a/tools/docker/streamlink_for_tvh_container.sh
+++ b/tools/docker/streamlink_for_tvh_container.sh
@@ -82,7 +82,9 @@ streamlink_install () {
     if apk add --no-cache py3-pip && apk add --no-cache --virtual .build-deps gcc musl-dev; then
         message 'PIP3: Updating and installing required packages.' 'info'
         if ! pip3 install --no-cache --upgrade setuptools; then message 'PIP3: Error while upgrading setuptools.' 'error'; fi
-        if ! pip3 install --no-cache streamlink; then message 'PIP3: Error while installing Streamlink.' 'error' ; fi
+        ## install the last compatible version of streamlink (2.3.0)
+        ## reference to build issues with streamlink 2.4.0 in Alpine
+        if ! pip3 install --no-cache streamlink==2.3.0; then message 'PIP3: Error while installing Streamlink.' 'error' ; fi
     else
       end 'APK: Critical error. Unable install required packages.' 1
     fi


### PR DESCRIPTION
Temporary fix for #6 .  It lets users install the latest working version (`2.3.0`) in Alpine.