### PR TITLE
Hotfix for introduction of lxml>=4.6.3 dependency

### DIFF
--- a/tools/docker/streamlink_for_tvh_container.sh
+++ b/tools/docker/streamlink_for_tvh_container.sh
@@ -94,7 +94,7 @@ streamlink_install () {
       end 'APK: Critical error. Unable install required packages.' 1
     fi
     message 'APK: Removing packages no longer required.' 'info'
-    apk del .build-deps gcc musl-dev
+    apk del .build-deps
   else
     end 'APK: Critical error. Unable to update pkg list. Check connectivity.' 1
   fi

--- a/tools/docker/streamlink_for_tvh_container.sh
+++ b/tools/docker/streamlink_for_tvh_container.sh
@@ -32,7 +32,7 @@
 # takes msg ($1) and status ($2) as args
 end () {
   echo '*********************************************'
-  echo '* Finished Streamlink install/update script *'
+  echo '* Finished Streamlink install/update script'
   echo "* Message: $1"
   echo '*********************************************'
   exit "$2"
@@ -75,7 +75,7 @@ streamlink_update () {
     fi
     # ensure lxml is installed. for more info, refer to https://github.com/cgomesu/tvhlink/issues/6
     if ! check_py_lxml; then
-      if ! apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/v3.13/community "py3-lxml>4.6.2"; then
+      if ! apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/v3.13/community "py3-lxml>4.6.3"; then
         end 'APK: Critical error. Unable to install compatible lxml.' 1
       fi
     fi 
@@ -91,7 +91,7 @@ streamlink_install () {
   if apk update; then
     message 'APK and PIP3: Installing required packages.' 'info'
     # install lxml from apk instead of pip: https://github.com/cgomesu/tvhlink/issues/6
-    if ! apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/v3.13/community py3-pip "py3-lxml>4.6.2"; then
+    if ! apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/v3.13/community py3-pip "py3-lxml>4.6.3"; then
       end 'APK: Critical error. Unable to install pip3 or lxml.' 1
     fi
     # upgrade setuptools and pip before streamlink installation
@@ -134,4 +134,4 @@ else
 fi
 
 message "Streamlink version: $(streamlink --version)." 'info'
-end 'Finished install/update script without errors.' 0
+end 'Reached EOF without critical errors.' 0

--- a/tools/docker/streamlink_for_tvh_container.sh
+++ b/tools/docker/streamlink_for_tvh_container.sh
@@ -12,6 +12,7 @@
 #########################################################################################
 # Notes
 #  - LinuxServer image comes with Python3 and the community repo source enabled
+#  - Streamlink 2.4.0 introduces lxml>=4.6.3 requirement
 #  - Keep this script POSIX sh compliant for compatibility
 #  - Use shellcheck
 #########################################################################################
@@ -24,11 +25,8 @@
 #  pip3, setuptools, streamlink
 #
 # Tested images (tvheadend:latest):
-#  x86-64:
-#   @sha256:cf7b44ddba0bde7d1dd225cf4a6faa8f24f5cf3dd841b212b4630a4ebc9636e3
-#   @sha256:c05411d415a097b7f7cd98eef7414e09e035e6f3c740b016a6b77769f1278475
 #  arm:
-#   @sha256:d5fc6f2e77beecb655ec5325f002109cd5d5c82c9d2fc3ee39dbb4fc098cd328
+#   @sha256:93283bf7f45fc04b74e4c4148b93baac4a07cd0e4a58a0a512b338d9fd5af11e
 #########################################################################################
 
 # takes msg ($1) and status ($2) as args
@@ -54,7 +52,7 @@ start () {
   echo '**********************************************'
 }
 
-# checks return error if requirements are not met
+# checks return error (1) if requirements are not met
 check_root () {
   if [ "$(id -u)" -ne 0 ]; then return 1; else return 0; fi
 }
@@ -63,19 +61,27 @@ check_streamlink () {
   if [ -z "$(command -v streamlink)" ]; then return 1; else return 0; fi
 }
 
+check_py_lxml () {
+  if ! python3 -c 'import lxml' > /dev/null 2>&1; then return 1; else return 0; fi
+}
+
 streamlink_update () {
-  if [ -z "$(command -v pip3)" ]; then end 'Unusual behavior: pip3 should be installed but is not.' 1;
+  if [ -z "$(command -v pip3)" ]; then
+    end 'PIP3: Critical error. pip3 should be installed but is not.' 1
   else
     # upgrade setuptools and pip first
     if ! pip3 install --no-cache-dir --upgrade setuptools pip; then
       message 'PIP3: Error while upgrading setuptools and pip.' 'error'
     fi
+    # ensure lxml is installed. for more info, refer to https://github.com/cgomesu/tvhlink/issues/6
+    if ! check_py_lxml; then
+      if ! apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/v3.13/community "py3-lxml>4.6.2"; then
+        end 'APK: Critical error. Unable to install compatible lxml.' 1
+      fi
+    fi 
     # upgrade streamlink last and exit on error
-    if pip3 install --no-cache-dir --upgrade streamlink; then
-      message "Streamlink version: $(streamlink --version)." 'info'
-    else
-      message "Streamlink update failed! Current version is still $(streamlink --version)." 'error'
-      end 'There was an error while trying to update streamlink.' 1
+    if ! pip3 install --no-cache-dir -U streamlink; then
+      end "PIP3: Critical error. Unable to upgrade Streamlink. Current version is still $(streamlink --version)." 1
     fi
   fi
 }
@@ -83,22 +89,33 @@ streamlink_update () {
 streamlink_install () {
   message 'APK: Updating pkg list.' 'info'
   if apk update; then
-    message 'APK: Installing required packages.' 'info'
-    if apk add --no-cache py3-pip && apk add --no-cache --virtual .build-deps gcc musl-dev; then
-        message 'PIP3: Updating and installing required packages.' 'info'
-        if ! pip3 install --no-cache-dir --upgrade setuptools pip; then message 'PIP3: Error while upgrading setuptools and pip.' 'error'; fi
-        ## install the last compatible version of streamlink (2.3.0)
-        ## reference to build issues with streamlink 2.4.0 in Alpine
-        if ! pip3 install --no-cache-dir streamlink==2.3.0; then message 'PIP3: Error while installing Streamlink.' 'error' ; fi
-    else
-      end 'APK: Critical error. Unable install required packages.' 1
+    message 'APK and PIP3: Installing required packages.' 'info'
+    # install lxml from apk instead of pip: https://github.com/cgomesu/tvhlink/issues/6
+    if ! apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/v3.13/community py3-pip "py3-lxml>4.6.2"; then
+      end 'APK: Critical error. Unable to install pip3 or lxml.' 1
     fi
+    # upgrade setuptools and pip before streamlink installation
+    if ! pip3 install --no-cache-dir -U setuptools pip; then 
+      message 'PIP3: Error while upgrading setuptools and pip.' 'error'
+    fi
+    # install temporary build dependencies in .build-deps
+    # required for building a few of the streamlink dependencies (e.g., pycryptodome)
+    if ! apk add --no-cache --virtual .build-deps gcc musl-dev; then
+        end 'APK: Critical error. Unable install required packages.' 1
+    fi
+    # let pip3 try to install until it succeed to install a version of streamlink
+    message 'PIP3: Installing Streamlink.' 'info'
+    pip3 install --no-cache-dir streamlink
+    # cleanup
     message 'APK: Removing packages no longer required.' 'info'
     apk del .build-deps
   else
     end 'APK: Critical error. Unable to update pkg list. Check connectivity.' 1
   fi
-  message 'Finsihed all APK and PIP3 updates and installs.' 'info'
+  # check that pip3 succeeded to install streamlink or raise critical error
+  if ! check_streamlink; then
+    end 'PIP3: Critical error. Cannot find Streamlink. Check above for installation errors.' 1
+  fi
 }
 
 
@@ -106,7 +123,7 @@ streamlink_install () {
 # main logic
 start
 
-trap 'end "Received a signal to stop" 1' INT HUP TERM
+trap "end 'Received a signal to stop' 1" INT HUP TERM
 
 if ! check_root; then end 'User is not root. This script needs root permission.' 1; fi
 
@@ -116,4 +133,5 @@ else
   message 'Installing Streamlink...' 'info'; streamlink_install
 fi
 
-end 'Completed without errors.' 0
+message "Streamlink version: $(streamlink --version)." 'info'
+end 'Finished install/update script without errors.' 0


### PR DESCRIPTION
- Fix for #6 
  - Install `lxml` directly from the `apk` repo (branch `v3.13`)